### PR TITLE
Add script to export OCR microservice

### DIFF
--- a/ocr_service/README.md
+++ b/ocr_service/README.md
@@ -1,0 +1,37 @@
+# OCR Microservice
+
+This folder contains a minimal microservice that performs OCR on images
+using Celery tasks. Each document directory is expected to contain PNG
+images corresponding to pages.
+
+## Usage
+
+1. Ensure `tesseract` and `redis` are installed and running.
+2. Start the Celery worker:
+
+```bash
+celery -A ocr_service.celery_app worker -l info
+```
+
+3. Call the task from Python:
+
+```python
+from ocr_service.tasks import process_document
+process_document.delay('/path/to/document')
+```
+
+The result will be a string containing the OCR text from all pages.
+
+## Exporting as a standalone repository
+
+Run `export_repo.sh` to copy this folder and initialize a new Git
+repository. By default the new repository will be created next to this
+project under `../ocr_microservice_repo`.
+
+```bash
+./export_repo.sh
+```
+
+You can pass a directory path as the first argument to place the new
+repository elsewhere.
+

--- a/ocr_service/celery_app.py
+++ b/ocr_service/celery_app.py
@@ -1,0 +1,4 @@
+from celery import Celery
+
+app = Celery('ocr_service')
+app.config_from_object('ocr_service.celery_config', namespace='CELERY')

--- a/ocr_service/celery_config.py
+++ b/ocr_service/celery_config.py
@@ -1,0 +1,5 @@
+broker_url = 'redis://localhost:6379/0'
+result_backend = 'redis://localhost:6379/1'
+
+accept_content = ['json']
+result_serializer = 'json'

--- a/ocr_service/export_repo.sh
+++ b/ocr_service/export_repo.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Create a standalone git repository for the OCR microservice.
+set -e
+TARGET_DIR="${1:-../ocr_microservice_repo}"
+mkdir -p "$TARGET_DIR"
+cp -r "$(dirname "$0")"/* "$TARGET_DIR"
+cd "$TARGET_DIR"
+rm -f export_repo.sh
+if [ ! -d .git ]; then
+    git init .
+    git add .
+    git commit -m "Initial commit of OCR microservice"
+fi
+printf 'Repository created at %s\n' "$TARGET_DIR"
+

--- a/ocr_service/tasks.py
+++ b/ocr_service/tasks.py
@@ -1,0 +1,28 @@
+import os
+from celery import chord
+from celery import shared_task
+from subprocess import check_output, CalledProcessError
+
+from .celery_app import app
+
+@shared_task(bind=True, max_retries=3)
+def process_page(self, page_path, language='eng'):
+    try:
+        output = check_output(['tesseract', page_path, 'stdout', '-l', language])
+        return output.decode('utf-8')
+    except CalledProcessError as exc:
+        raise self.retry(exc=exc, countdown=10)
+
+@shared_task(bind=True)
+def process_document(self, document_dir, language='eng'):
+    pages = sorted([
+        os.path.join(document_dir, f) for f in os.listdir(document_dir)
+        if f.lower().endswith('.png')
+    ])
+    callback = document_finished.s()
+    header = [process_page.s(page, language=language) for page in pages]
+    return chord(header)(callback)
+
+@shared_task
+def document_finished(pages_results):
+    return '\n'.join(pages_results)


### PR DESCRIPTION
## Summary
- add `export_repo.sh` to generate a standalone repo for the OCR microservice
- document how to use the script in the microservice README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68802dad7d648321905b7bbda630aa49